### PR TITLE
Fix getUser() request endpoint

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -38,7 +38,7 @@ function registerStoreModule(store) {
              * @returns {*}
              */
             getUser() {
-                return this.$axios.get('me');
+                return this.$axios.get('api/me');
             },
 
             /**


### PR DESCRIPTION
### Change getUser() request endpoint from 'me' to 'api/me'.

Before:
```
            /**
             * Get the user information
             * @returns {*}
             */
            getUser() {
                return this.$axios.get('me');
            },
```

After:
```
            /**
             * Get the user information
             * @returns {*}
             */
            getUser() {
                return this.$axios.get('api/me');
            },
```